### PR TITLE
Update action.yml with node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,5 +7,5 @@ inputs:
     description: "your npm token"
     required: true
 runs:
-  using: "node12"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Hello, dear maintainer

Recently I received a deprecate warning from github when using action

> The following actions uses node12 which is deprecated and will be forced to run on node16: filipstefansson/set-npm-token-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
>
> The following actions use a deprecated Node.js version and will be forced to run on node20: filipstefansson/set-npm-token-action@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

I would like to propose this PR to fix the above warning.

Thank you!